### PR TITLE
Added required version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![BuyMeCoffee][buymecoffeebadge]][buymecoffee]
 
-_Companion Component to [node-red-contrib-home-assistant-websocket](https://github.com/zachowj/node-red-contrib-home-assistant-websocket) to integrate Node-RED with Home Assistant._
+_Companion Component to [node-red-contrib-home-assistant-websocket](https://github.com/zachowj/node-red-contrib-home-assistant-websocket) to integrate Node-RED with Home Assistant. (minimum version 0.17.1)_
 
 ## Installation
 


### PR DESCRIPTION
I was struggling to figure out why it wasn't working for me until Villhellm in the discord server pointed out that the version of `node-red-contrib-home-assistant-websocket` that came pre-installed with the HASSIO version of NodeRed doesn't work, and that I needed to upgrade it. Adding the minimum version number required to make it a bit more obvious for people to check for an update even if they already have it installed.