### PR TITLE
Add version to manifest.json

### DIFF
--- a/custom_components/nodered/manifest.json
+++ b/custom_components/nodered/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "nodered",
   "name": "Node-RED",
+  "version": "0.4.5",
   "documentation": "https://zachowj.github.io/node-red-contrib-home-assistant-websocket/guide/custom_integration/",
   "issue_tracker": "https://github.com/zachowj/hass-node-red/issues",
   "dependencies": [],


### PR DESCRIPTION
Starting with Home Assistant 2021.3.0, components must include a version in the manifest