### PR TITLE
removed device_state_attributes

### DIFF
--- a/custom_components/nodered/__init__.py
+++ b/custom_components/nodered/__init__.py
@@ -148,11 +148,6 @@ class NodeRedEntity(Entity):
         return self._config.get(CONF_UNIT_OF_MEASUREMENT)
 
     @property
-    def device_state_attributes(self) -> Optional[Dict[str, Any]]:
-        """Return the state attributes."""
-        return self.attr
-
-    @property
     def device_info(self) -> Optional[Dict[str, Any]]:
         """Return device specific attributes."""
         info = None

--- a/custom_components/nodered/__init__.py
+++ b/custom_components/nodered/__init__.py
@@ -8,8 +8,6 @@ import asyncio
 import logging
 from typing import Any, Dict, Optional, Union
 
-from homeassistant.const import MAJOR_VERSION, MINOR_VERSION
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_DEVICE_CLASS,
@@ -17,6 +15,8 @@ from homeassistant.const import (
     CONF_STATE,
     CONF_TYPE,
     CONF_UNIT_OF_MEASUREMENT,
+    MAJOR_VERSION,
+    MINOR_VERSION,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import (

--- a/custom_components/nodered/__init__.py
+++ b/custom_components/nodered/__init__.py
@@ -8,6 +8,8 @@ import asyncio
 import logging
 from typing import Any, Dict, Optional, Union
 
+from homeassistant.const import MAJOR_VERSION, MINOR_VERSION
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_DEVICE_CLASS,
@@ -108,6 +110,12 @@ class NodeRedEntity(Entity):
         self._node_id = config[CONF_NODE_ID]
         self._remove_signal_discovery_update = None
         self._remove_signal_entity_update = None
+
+        # changed property name since 2021.12
+        if MAJOR_VERSION >= 2022 or (MAJOR_VERSION == 2021 and MINOR_VERSION == 12):
+            NodeRedEntity.extra_state_attributes = property(lambda self: self.attrs)
+        else:
+            NodeRedEntity.device_state_attributes = property(lambda self: self.attrs)
 
     @property
     def should_poll(self) -> bool:

--- a/custom_components/nodered/__init__.py
+++ b/custom_components/nodered/__init__.py
@@ -113,9 +113,9 @@ class NodeRedEntity(Entity):
 
         # changed property name since 2021.12
         if MAJOR_VERSION >= 2022 or (MAJOR_VERSION == 2021 and MINOR_VERSION == 12):
-            NodeRedEntity.extra_state_attributes = property(lambda self: self.attrs)
+            NodeRedEntity.extra_state_attributes = property(lambda self: self.attr)
         else:
-            NodeRedEntity.device_state_attributes = property(lambda self: self.attrs)
+            NodeRedEntity.device_state_attributes = property(lambda self: self.attr)
 
     @property
     def should_poll(self) -> bool:


### PR DESCRIPTION
since HA2021.12.dev0 , remove device_state_attributes to avoid warnings like following:
```
Entity .. (<class 'custom_components.nodered.binary_sensor.NodeRedBinarySensor'>) implements device_state_attributes. Please report it to the custom component author.
Entity ... (<class 'custom_components.nodered.switch.NodeRedSwitch'>) implements device_state_attributes. Please report it to the custom component author.
Entity ... (<class 'custom_components.nodered.sensor.NodeRedSensor'>) implements device_state_attributes. Please report it to the custom component author.
```
