### PR TITLE
Fix failure during loading due to MQTT init

### DIFF
--- a/custom_components/nodered/manifest.json
+++ b/custom_components/nodered/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "nodered",
   "name": "Node-RED Companion",
+  "after_dependencies": ["mqtt"],
   "codeowners": ["@zachowj"],
   "config_flow": true,
   "dependencies": [],


### PR DESCRIPTION
Fixes #238

Add MQTT to dependencies to make sure that component is loaded after it, so initialization does not fail