### PR TITLE
Update import for get_agent_manager

### DIFF
--- a/custom_components/nodered/websocket.py
+++ b/custom_components/nodered/websocket.py
@@ -8,8 +8,16 @@ from hassil.recognize import RecognizeResult
 from homeassistant.components import device_automation
 from homeassistant.components.conversation import (
     HOME_ASSISTANT_AGENT,
-    get_agent_manager,
 )
+
+try:
+    from homeassistant.components.conversation import get_agent_manager
+except ImportError:
+    # _get_agent_manager was renamed to get_agent_manager in 2024.4.0
+    from homeassistant.components.conversation import (
+        _get_agent_manager as get_agent_manager,
+    )
+
 from homeassistant.components.conversation.default_agent import DefaultAgent
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.device_automation.exceptions import (

--- a/custom_components/nodered/websocket.py
+++ b/custom_components/nodered/websocket.py
@@ -8,7 +8,7 @@ from hassil.recognize import RecognizeResult
 from homeassistant.components import device_automation
 from homeassistant.components.conversation import (
     HOME_ASSISTANT_AGENT,
-    _get_agent_manager,
+    get_agent_manager,
 )
 from homeassistant.components.conversation.default_agent import DefaultAgent
 from homeassistant.components.device_automation import DeviceAutomationType
@@ -342,7 +342,7 @@ async def websocket_sentence(
         _LOGGER.info(f"Sentence trigger removed: {sentences}")
 
     try:
-        default_agent = await _get_agent_manager(hass).async_get_agent(
+        default_agent = await get_agent_manager(hass).async_get_agent(
             HOME_ASSISTANT_AGENT
         )
         assert isinstance(default_agent, DefaultAgent)


### PR DESCRIPTION
Installation was failing with the following error in HA logs:

```
ERROR (MainThread) [homeassistant.config_entries] Error occurred loading flow for integration nodered: cannot import name '_get_agent_manager' from 'homeassistant.components.conversation' (/usr/src/homeassistant/homeassistant/components/conversation/__init__.py)
```

It looks like the name changed in a recent commit https://github.com/home-assistant/core/commit/f01235ef746823a8f146c603bf732df6a6061706. 

This change looks to have fixed it for me when doing a manual install. I admittedly didn't look too much deeper than this but opening it as a suggestion.