### PR TITLE
Remove warning about using incorrect schema for entity service registration

### DIFF
--- a/custom_components/nodered/binary_sensor.py
+++ b/custom_components/nodered/binary_sensor.py
@@ -3,12 +3,12 @@
 from numbers import Number
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.components.lock import LockState
 from homeassistant.const import (
     CONF_STATE,
     STATE_HOME,
     STATE_ON,
     STATE_OPEN,
-    STATE_UNLOCKED,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -45,7 +45,7 @@ class NodeRedBinarySensor(NodeRedEntity, BinarySensorEntity):
         STATE_ON,
         STATE_OPEN,
         STATE_HOME,
-        STATE_UNLOCKED,
+        LockState.UNLOCKED,
     )
     _component = CONF_BINARY_SENSOR
 

--- a/custom_components/nodered/switch.py
+++ b/custom_components/nodered/switch.py
@@ -31,13 +31,11 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-SERVICE_TRIGGER_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_ENTITY_ID): cv.entity_ids,
-        vol.Optional(CONF_OUTPUT_PATH, default="0"): cv.string,
-        vol.Optional(CONF_MESSAGE, default={}): dict,
-    }
-)
+SERVICE_TRIGGER_SCHEMA = {
+    vol.Required(CONF_ENTITY_ID): cv.entity_ids,
+    vol.Optional(CONF_OUTPUT_PATH, default="0"): cv.string,
+    vol.Optional(CONF_MESSAGE, default={}): dict,
+}
 EVENT_TRIGGER_NODE = "automation_triggered"
 EVENT_DEVICE_TRIGGER = "device_trigger"
 


### PR DESCRIPTION
`2024-10-12 12:00:30.700 WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration 'nodered' registers an entity service with a non entity service schema which will stop working in HA Core 2025.9 at custom_components/nodered/switch.py, line 62: platform.async_register_entity_service(, please create a bug report at https://github.com/zachowj/hass-node-red/issues`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved state management in the binary sensor with clearer definitions for lock states.

- **Bug Fixes**
	- Simplified the service trigger schema in the switch component, maintaining functionality while enhancing clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->