### PR TITLE
Remove warning about using incorrect schema for entity service registration

### DIFF
--- a/custom_components/nodered/switch.py
+++ b/custom_components/nodered/switch.py
@@ -31,13 +31,12 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-SERVICE_TRIGGER_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_ENTITY_ID): cv.entity_ids,
-        vol.Optional(CONF_OUTPUT_PATH, default="0"): cv.string,
-        vol.Optional(CONF_MESSAGE, default={}): dict,
-    }
-)
+SERVICE_TRIGGER_SCHEMA = {
+    vol.Required(CONF_ENTITY_ID): cv.entity_ids,
+    vol.Optional(CONF_OUTPUT_PATH, default="0"): cv.string,
+    vol.Optional(CONF_MESSAGE, default={}): dict,
+}
+
 EVENT_TRIGGER_NODE = "automation_triggered"
 EVENT_DEVICE_TRIGGER = "device_trigger"
 


### PR DESCRIPTION
`2024-10-12 12:00:30.700 WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration 'nodered' registers an entity service with a non entity service schema which will stop working in HA Core 2025.9 at custom_components/nodered/switch.py, line 62: platform.async_register_entity_service(, please create a bug report at https://github.com/zachowj/hass-node-red/issues`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified the schema definition for the Node-RED switch integration without altering existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->