### PR TITLE
Fix build failure from #377

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ colorlog==6.10.1
 homeassistant
 pre-commit
 hassil
-aiodns>=3.6.1
+# pin pycares due to breaking changes in 5.0 which aiodns is not ready for
+pycares<5.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,4 @@
 pytest-homeassistant-custom-component
 hassil
-aiodns>=3.6.1
+# pin pycares due to breaking changes in 5.0 which aiodns is not ready for
+pycares<5.0


### PR DESCRIPTION
#377 had a build failure, this tries to fix it.

### The situation

pycares 4.11.0 -> 5.0.0 (Dec 10) had breaking changes
We pull this in via:

homeassistant -> [aiohttp-asyncmdnsresolver ->] aiodns -> pycares

aiodns v3.6.1 (4 days ago) pinned pycares at "<5" https://github.com/aio-libs/aiodns/commit/a85b558b71cf9464a4c876f57490224ee98e3829


### Suggestions?

I'm not well versed in how python canon handles packages, the floating versions feels strange coming from C#.

Is there a better way to do this?