### PR TITLE
Fix incorrect async_remove_config_entry_device signature causing device removal failure

### DIFF
--- a/custom_components/nodered/__init__.py
+++ b/custom_components/nodered/__init__.py
@@ -76,7 +76,7 @@ async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
 
 async def async_remove_config_entry_device(
-    hass: HomeAssistant, device_entry: DeviceEntry
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: DeviceEntry
 ) -> bool:
     """Remove a entry from the device registry."""
     entity_registry = async_get(hass)


### PR DESCRIPTION
Description
Home Assistant fails to remove devices created by the Node-RED Companion integration.
The UI shows “Unknown error”, and logs report:
```yaml
TypeError: async_remove_config_entry_device() takes 2 positional arguments but 3 were given
```
This happens because Home Assistant calls the method with (hass, config_entry, device_entry), but the integration only defines a 2‑argument version.

This PR updates the method signature to match Home Assistant’s expected interface and ensures device removal works correctly from the UI.

Fixes: #398